### PR TITLE
fix: error where existsAt returns unknown

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,9 @@ class DeleteSourceMapWebpackPlugin {
       .forEach((name) => {
         countMatchMapAssets += 1
         const { existsAt } = stats.compilation.assets[name]
-        fs.unlinkSync(existsAt)
+        if (existsAt) {
+          fs.unlinkSync(existsAt)
+        }
       })
       console.log(`⭐⭐⭐removed source map url: ${countMatchAssets} asset(s) processed`);
       console.log(`⭐⭐⭐deleted map file: ${countMatchMapAssets} asset(s) processed`);


### PR DESCRIPTION
I'm seeing this error during compile.

```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string or an instance of Buffer or URL. 
Received undefined at Object.unlinkSync (node:fs:1705:10)
at /Users/jeff/actions-runner/_work/my_project/node_modules/delete-sourcemap-webpack-plugin/index.js:33:12
```